### PR TITLE
Remove efficiency and peakGFlops from reporter

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -539,7 +539,6 @@ def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseD
         param("perf-l2-write-hits",       globalParameters["PerfModelL2WriteHits"])
         param("perf-l2-read-bw-mul",      globalParameters["PerfModelL2ReadBwMul"])
         param("perf-read-efficiency",     globalParameters["PerfModelReadEfficiency"])
-        param("perf-ops-per-cycle",       globalParameters["PerfModelOpsPerCycle"])
 
 
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -199,7 +199,6 @@ globalParameters["PerfModelL2ReadHits"] = 0.0
 globalParameters["PerfModelL2WriteHits"] = 0.15
 globalParameters["PerfModelL2ReadBwMul"] = 2
 globalParameters["PerfModelReadEfficiency"] = 0.85
-globalParameters["PerfModelOpsPerCycle"] = 64
 
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -85,7 +85,7 @@ namespace Tensile
                         new LogReporter(LogLevel::Debug,
                                         {BenchmarkRunNumber, ProblemProgress, SolutionProgress,
                                          OperationIdentifier, ProblemSizes, SolutionName,
-                                         Validation, TimeUS, SpeedGFlops, Empty, Efficiency,
+                                         Validation, TimeUS, SpeedGFlops, Empty, 
                                          TotalGranularity, TilesPerCu, NumCus,
                                          Tile0Granularity, Tile1Granularity, CuGranularity,
                                          WaveGranularity, 

--- a/Tensile/Source/client/include/PerformanceReporter.hpp
+++ b/Tensile/Source/client/include/PerformanceReporter.hpp
@@ -50,7 +50,7 @@ namespace Tensile
     
             static std::shared_ptr<PerformanceReporter> Default(po::variables_map const& args);
         
-            PerformanceReporter(int deviceIndex, double l2ReadHits, double l2WriteHits, double l2ReadBwMultiplier, double readEff, int opsPerCycle);
+            PerformanceReporter(int deviceIndex, double l2ReadHits, double l2WriteHits, double l2ReadBwMultiplier, double readEff);
 
             virtual void reportValue_int(std::string const& key, int64_t value) override;
             
@@ -64,7 +64,7 @@ namespace Tensile
 
             virtual void postSolution() override;
             
-            void    setPerfModel(double l2ReadHits, double l2WriteHits, double l2ReadBwMul, double readEff, int opsPerCycle);
+            void    setPerfModel(double l2ReadHits, double l2WriteHits, double l2ReadBwMul, double readEff);
             void    setNumCUs();
             void    setMemoryBusWidth();
             void    setClockMhz(double value);

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -108,7 +108,7 @@ namespace Tensile
             const std::string Empty                 = "empty";
             const std::string Efficiency            = "efficiency";
             const std::string NumCus                = "num-cus";
-            const std::string PeakGFlops            = "peak-gflops"
+            const std::string PeakGFlops            = "peak-gflops";
 
             // Hardware monitoring
             const std::string TempEdge              = "temp-edge";

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -46,65 +46,78 @@ namespace Tensile
 
         namespace ResultKey
         {
-            const std::string BenchmarkRunNumber = "run";
+            const std::string BenchmarkRunNumber    = "run";
 
             // Problem definition
-            const std::string ProblemIndex = "problem-index";
-            const std::string ProblemCount = "problem-count";
-            const std::string ProblemProgress = "problem-progress";
-            const std::string OperationIdentifier = "operation";
+            const std::string ProblemIndex          = "problem-index";
+            const std::string ProblemCount          = "problem-count";
+            const std::string ProblemProgress       = "problem-progress";
+            const std::string OperationIdentifier   = "operation";
 
-            const std::string ASizes = "a-sizes";
-            const std::string BSizes = "b-sizes";
-            const std::string CSizes = "c-sizes";
-            const std::string DSizes = "d-sizes";
+            const std::string ASizes                = "a-sizes";
+            const std::string BSizes                = "b-sizes";
+            const std::string CSizes                = "c-sizes";
+            const std::string DSizes                = "d-sizes";
 
-            const std::string AStrides = "a-strides";
-            const std::string BStrides = "b-strides";
-            const std::string CStrides = "c-strides";
-            const std::string DStrides = "d-strides";
+            const std::string AStrides              = "a-strides";
+            const std::string BStrides              = "b-strides";
+            const std::string CStrides              = "c-strides";
+            const std::string DStrides              = "d-strides";
 
-            const std::string LDA = "lda";
-            const std::string LDB = "ldb";
-            const std::string LDC = "ldc";
-            const std::string LDD = "ldd";
+            const std::string LDA                   = "lda";
+            const std::string LDB                   = "ldb";
+            const std::string LDC                   = "ldc";
+            const std::string LDD                   = "ldd";
 
-            const std::string TotalFlops   = "total-flops";
-            const std::string ProblemSizes = "problem-sizes";
+            const std::string TotalFlops            = "total-flops";
+            const std::string ProblemSizes          = "problem-sizes";
 
             // Solution information
-            const std::string SolutionName = "solution";
-            const std::string SolutionIndex = "solution-index";
-            const std::string SolutionProgress = "solution-progress";
+            const std::string SolutionName          = "solution";
+            const std::string SolutionIndex         = "solution-index";
+            const std::string SolutionProgress      = "solution-progress";
 
             // Performance-related
-            const std::string Validation  = "validation";
-            const std::string TimeUS      = "time-us";
-            const std::string SpeedGFlops = "gflops";
-            const std::string EnqueueTime = "enqueue-time";
+            const std::string Validation            = "validation";
+            const std::string TimeUS                = "time-us";
+            const std::string SpeedGFlops           = "gflops";
+            const std::string EnqueueTime           = "enqueue-time";
 
             // Performance estimation and granularity
-            const std::string Tile0Granularity = "tile0-granularity";
-            const std::string Tile1Granularity = "tile1-granularity";
-            const std::string CuGranularity = "cu-granularity";
-            const std::string WaveGranularity = "wave-granularity";
-            const std::string TotalGranularity = "total-granularity";
-            const std::string TilesPerCu = "tiles-per-cu";
+            const std::string Tile0Granularity      = "tile0-granularity";
+            const std::string Tile1Granularity      = "tile1-granularity";
+            const std::string CuGranularity         = "cu-granularity";
+            const std::string WaveGranularity       = "wave-granularity";
+            const std::string TotalGranularity      = "total-granularity";
+            const std::string TilesPerCu            = "tiles-per-cu";
 
-            const std::string MemReadBytes   = "mem-read-bytes";
-            const std::string MemWriteBytes  = "mem-write-bytes";
-            const std::string Empty          = "empty";
-            const std::string Efficiency     = "efficiency";
-            const std::string NumCus         = "num-cus";
+            const std::string MemReadBytes          = "mem-read-bytes";
+            const std::string MemWriteBytes         = "mem-write-bytes";
+            const std::string MemReadUs             = "mem-read-us";
+            const std::string MemWriteUs            = "mem-write-us";
+            const std::string MemGlobalReads        = "mem-global-reads";
+            const std::string MemGlobalWrites       = "mem-global-writes";
+            const std::string AluUs                 = "alu-us";
+
+            const std::string L2ReadHits            = "perf-l2-read-hits";
+            const std::string L2WriteHits           = "perf-l2-write-hits";
+            const std::string L2ReadBwMul           = "perf-l2-read-bw-mul";
+            const std::string L2BandwidthMBps       = "perf-l2-bandwidth-mbps";
+            const std::string OpsPerCycle           = "perf-ops-per-cycle";
+
+            const std::string Empty                 = "empty";
+            const std::string Efficiency            = "efficiency";
+            const std::string NumCus                = "num-cus";
+            const std::string PeakGFlops            = "peak-gflops"
 
             // Hardware monitoring
-            const std::string TempEdge            = "temp-edge";
-            const std::string ClockRateSys        = "clock-sys";
-            const std::string ClockRateSOC        = "clock-soc";
-            const std::string ClockRateMem        = "clock-mem";
-            const std::string DeviceIndex         = "device-idx";
-            const std::string FanSpeedRPMs        = "fan-rpm";
-            const std::string HardwareSampleCount = "hardware-samples";
+            const std::string TempEdge              = "temp-edge";
+            const std::string ClockRateSys          = "clock-sys";
+            const std::string ClockRateSOC          = "clock-soc";
+            const std::string ClockRateMem          = "clock-mem";
+            const std::string DeviceIndex           = "device-idx";
+            const std::string FanSpeedRPMs          = "fan-rpm";
+            const std::string HardwareSampleCount   = "hardware-samples";
         };
         
         class ResultReporter: public RunListener

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -103,7 +103,6 @@ namespace Tensile
             const std::string L2WriteHits           = "perf-l2-write-hits";
             const std::string L2ReadBwMul           = "perf-l2-read-bw-mul";
             const std::string L2BandwidthMBps       = "perf-l2-bandwidth-mbps";
-            const std::string OpsPerCycle           = "perf-ops-per-cycle";
 
             const std::string Empty                 = "empty";
             const std::string Efficiency            = "efficiency";

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -117,8 +117,6 @@ namespace Tensile
 
             m_timeInSolution = double_millis::zero();
             m_numEnqueuesInSolution = 0;
-            
-            m_reporter->report(ResultKey::Efficiency, perf.efficiency);
         }
 
         bool BenchmarkTimer::needMoreRunsInSolution() const

--- a/Tensile/Source/client/source/PerformanceReporter.cpp
+++ b/Tensile/Source/client/source/PerformanceReporter.cpp
@@ -43,24 +43,22 @@ namespace Tensile
             double  l2WriteHits = args["perf-l2-write-hits"].as<double>();
             double  l2ReadBwMultiplier = args["perf-l2-read-bw-mul"].as<double>();
             double  readEff = args["perf-read-efficiency"].as<double>();
-            int     opsPerCycle = args["perf-ops-per-cycle"].as<int>();
  
-            return std::make_shared<PerformanceReporter>(deviceIndex, l2ReadHits, l2WriteHits, l2ReadBwMultiplier, readEff, opsPerCycle);
+            return std::make_shared<PerformanceReporter>(deviceIndex, l2ReadHits, l2WriteHits, l2ReadBwMultiplier, readEff);
         }
         
-        PerformanceReporter::PerformanceReporter(int deviceIndex, double l2ReadHits, double l2WriteHits, double l2ReadBwMultiplier, double readEff, int opsPerCycle)
+        PerformanceReporter::PerformanceReporter(int deviceIndex, double l2ReadHits, double l2WriteHits, double l2ReadBwMultiplier, double readEff)
         {
             hipGetDeviceProperties(&m_props, deviceIndex);
             setNumCUs();
             setMemoryBusWidth();
-            setPerfModel(l2ReadHits, l2WriteHits, l2ReadBwMultiplier, readEff, opsPerCycle);
+            setPerfModel(l2ReadHits, l2WriteHits, l2ReadBwMultiplier, readEff);
             m_deviceProps = true;
             
             perf.l2ReadHitRate = getL2ReadHits();
             perf.l2WriteHitRate = getL2WriteHits();
             perf.l2ReadBwMul = getL2ReadBwMultiplier();
             perf.readEff = getReadEff();
-            perf.opsPerCycle = getOpsPerCycle();
             perf.CUs = getNumCUs();
         }
         
@@ -148,13 +146,13 @@ namespace Tensile
             m_memBandwidthMBps = std::numeric_limits<double>::quiet_NaN();
         }
         
-        void PerformanceReporter::setPerfModel(double l2ReadHits, double l2WriteHits, double l2ReadBwMultiplier, double readEff, int opsPerCycle)
+        void PerformanceReporter::setPerfModel(double l2ReadHits, double l2WriteHits, double l2ReadBwMultiplier, double readEff)
         {
             m_l2ReadHits = l2ReadHits;
             m_l2WriteHits = l2WriteHits;
             m_l2ReadBwMul = l2ReadBwMultiplier;
             m_readEff = readEff;
-            m_ops = opsPerCycle;
+            m_ops = 64;
         }
         
         void PerformanceReporter::setNumCUs()

--- a/Tensile/Source/client/source/PerformanceReporter.cpp
+++ b/Tensile/Source/client/source/PerformanceReporter.cpp
@@ -94,11 +94,7 @@ namespace Tensile
         {
             m_clockMhz = value;
             perf.clock = getClockMhz();
-            
-            if(!std::isnan(m_clockMhz) && m_deviceProps)
-            {
-                setPeakGFlops();
-            }
+            setPeakGFlops();
         }
 
         void PerformanceReporter::setMemClockMhz(double value)

--- a/Tensile/Source/client/source/PerformanceReporter.cpp
+++ b/Tensile/Source/client/source/PerformanceReporter.cpp
@@ -54,7 +54,8 @@ namespace Tensile
             setMemoryBusWidth();
             setPerfModel(l2ReadHits, l2WriteHits, l2ReadBwMultiplier, readEff);
             m_deviceProps = true;
-            
+            m_ops = 64;
+ 
             perf.l2ReadHitRate = getL2ReadHits();
             perf.l2WriteHitRate = getL2WriteHits();
             perf.l2ReadBwMul = getL2ReadBwMultiplier();
@@ -64,13 +65,16 @@ namespace Tensile
         
         void PerformanceReporter::reportValue_uint(std::string const& key, uint64_t value) 
         {
-            if(key == ResultKey::SpeedGFlops && m_deviceProps) 
-            {
-                reportValue_numeric(key, value);
-            }
+            reportValue_numeric(key, value);
         }
 
         void PerformanceReporter::reportValue_double(std::string const& key, double value) 
+        {
+            reportValue_numeric(key, value);
+        }
+
+        template <typename T> 
+        void PerformanceReporter::reportValue_numeric(std::string const& key, T value)
         {
             if(key == ResultKey::ClockRateSys && m_deviceProps)
             {
@@ -80,15 +84,6 @@ namespace Tensile
             {
                 setMemClockMhz(value);
             }
-            if(key == ResultKey::SpeedGFlops && m_deviceProps) 
-            {
-                reportValue_numeric(key, value);
-            }
-        }
-
-        template <typename T> 
-        void PerformanceReporter::reportValue_numeric(std::string const& key, T value)
-        {
             if(key == ResultKey::SpeedGFlops && m_deviceProps)
             {
                 setEfficiency(value);
@@ -121,7 +116,7 @@ namespace Tensile
 
         void PerformanceReporter::setPeakGFlops()
         {
-            m_peakGFlops = getNumCUs()*getOpsPerCycle()*getL2ReadBwMultiplier()*m_clockMhz/1000;
+            m_peakGFlops = getNumCUs()*getL2ReadBwMultiplier()*getOpsPerCycle()*m_clockMhz/1000;
             perf.peakGFlops = getPeakGFlops();
         }
 
@@ -152,7 +147,6 @@ namespace Tensile
             m_l2WriteHits = l2WriteHits;
             m_l2ReadBwMul = l2ReadBwMultiplier;
             m_readEff = readEff;
-            m_ops = 64;
         }
         
         void PerformanceReporter::setNumCUs()


### PR DESCRIPTION
- Also re-added keys so that parse-results can work (I removed the mem-read-us, mem-write-us, and alu-us keys, which would case parse-results.py to not work).